### PR TITLE
Refactor task-related tests and services to improve date handling and validation

### DIFF
--- a/src/app/components/task-new/task-new.component.spec.ts
+++ b/src/app/components/task-new/task-new.component.spec.ts
@@ -20,42 +20,65 @@ describe('TaskNewComponent', () => {
     expect(component).toBeTruthy();
   });
 
-  it('should emit addNewTask with correct task on add button click', () => {
-    const taskName = 'Test Task';
-    const taskDate = '2023-12-31';
-    spyOn(component.addNewTask, 'emit');
+  describe('addTask', () => {
+    it('should emit addNewTask with correct task on add button click', () => {
+      const taskName = 'Test Task';
+      const taskDate = '2023-12-31';
+      spyOn(component.addNewTask, 'emit');
 
-    const nameInput: HTMLInputElement = fixture.debugElement.query(
-      By.css('[data-testid="task-name-input"]')
-    ).nativeElement;
-    const dateInput: HTMLInputElement = fixture.debugElement.query(
-      By.css('[data-testid="due-date-input"]')
-    ).nativeElement;
-    nameInput.value = taskName;
-    dateInput.value = taskDate;
-    nameInput.dispatchEvent(new Event('input'));
-    dateInput.dispatchEvent(new Event('input'));
-    fixture.detectChanges();
+      const nameInput: HTMLInputElement = fixture.debugElement.query(
+        By.css('[data-testid="task-name-input"]')
+      ).nativeElement;
+      const dateInput: HTMLInputElement = fixture.debugElement.query(
+        By.css('[data-testid="due-date-input"]')
+      ).nativeElement;
+      nameInput.value = taskName;
+      dateInput.value = taskDate;
+      nameInput.dispatchEvent(new Event('input'));
+      dateInput.dispatchEvent(new Event('input'));
+      fixture.detectChanges();
 
-    const addButton: HTMLButtonElement = fixture.debugElement.query(
-      By.css('[data-testid="add-task-button"]')
-    ).nativeElement;
-    addButton.click();
-    fixture.detectChanges();
+      const addButton: HTMLButtonElement = fixture.debugElement.query(
+        By.css('[data-testid="add-task-button"]')
+      ).nativeElement;
+      addButton.click();
+      fixture.detectChanges();
 
-    expect(component.addNewTask.emit).toHaveBeenCalledWith({
-      name: taskName,
-      dueDate: taskDate,
+      expect(component.addNewTask.emit).toHaveBeenCalledWith({
+        name: taskName,
+        dueDate: taskDate,
+      });
+    });
+
+    it('should not emit addNewTask on add button click if form is invalid', () => {
+      spyOn(component.addNewTask, 'emit');
+      const addButton: HTMLButtonElement = fixture.debugElement.query(
+        By.css('[data-testid="add-task-button"]')
+      ).nativeElement;
+      addButton.click();
+      fixture.detectChanges();
+      expect(component.addNewTask.emit).not.toHaveBeenCalled();
+    });
+
+    it('should not emit addNewTask if form is invalid when addTask() is called', () => {
+      spyOn(component.addNewTask, 'emit');
+      // Ensure the form is invalid
+      component.newTaskForm.controls['taskName'].setValue('');
+
+      component.addTask();
+      expect(component.addNewTask.emit).not.toHaveBeenCalled();
     });
   });
 
-  it('should emit cancelSave on cancel button click', () => {
-    spyOn(component.cancelSave, 'emit');
-    const cancelButton: HTMLButtonElement = fixture.debugElement.query(
-      By.css('[data-testid="cancel-button"]')
-    ).nativeElement;
-    cancelButton.click();
-    fixture.detectChanges();
-    expect(component.cancelSave.emit).toHaveBeenCalled();
+  describe('cancelClick', () => {
+    it('should emit cancelSave on cancel button click', () => {
+      spyOn(component.cancelSave, 'emit');
+      const cancelButton: HTMLButtonElement = fixture.debugElement.query(
+        By.css('[data-testid="cancel-button"]')
+      ).nativeElement;
+      cancelButton.click();
+      fixture.detectChanges();
+      expect(component.cancelSave.emit).toHaveBeenCalled();
+    });
   });
 });

--- a/src/app/components/task/task.component.ts
+++ b/src/app/components/task/task.component.ts
@@ -29,11 +29,4 @@ export class TaskComponent {
     this.bodyElement.classList.add('inheritCursors');
     this.bodyElement.style.cursor = 'grabbing';
   }
-
-  // Getter for validating dueDate
-  get validDueDate(): Date | null {
-    if (!this.task.dueDate) return null;
-    const date = new Date(this.task.dueDate);
-    return isNaN(date.getTime()) ? null : date;
-  }
 }

--- a/src/app/services/date.service.spec.ts
+++ b/src/app/services/date.service.spec.ts
@@ -22,6 +22,10 @@ describe('DateService', () => {
     expect(service.convertToISO(validDate)).toBe(expectedISO);
   });
 
+  it('should return null when converting a null date string', () => {
+    expect(service.convertToISO(null)).toBeNull();
+  });
+
   it('should convert a valid ISO string to YYYY-MM-DD format', () => {
     const isoString = '2023-01-01T00:00:00.000Z';
     expect(service.convertToDateInput(isoString)).toBe('2023-01-01');

--- a/src/app/services/task.service.spec.ts
+++ b/src/app/services/task.service.spec.ts
@@ -14,10 +14,17 @@ import {
   HttpResponse,
 } from '@angular/common/http';
 import { of, throwError } from 'rxjs';
+import { DateService } from '../../app/services/date.service';
 
 describe('TaskService', () => {
   let service: TaskService;
   let httpRequests: HttpRequest<any>[] = [];
+
+  // Stub for DateService
+  const stubDateService = {
+    convertToDateInput: (date: string) => `converted-${date}`,
+    convertToISO: (date: string) => `iso-${date}`,
+  };
 
   const testInterceptor: HttpInterceptorFn = (
     req: HttpRequest<any>,
@@ -50,11 +57,18 @@ describe('TaskService', () => {
     dueDate: '2020-01-01',
   };
 
+  // Expected task for methods that apply date conversion
+  const expectedConvertedTask: Task = {
+    ...mockTask,
+    dueDate: stubDateService.convertToDateInput(mockTask.dueDate),
+  };
+
   beforeEach(() => {
     httpRequests = [];
     TestBed.configureTestingModule({
       providers: [
         TaskService,
+        { provide: DateService, useValue: stubDateService },
         provideHttpClient(withInterceptors([testInterceptor])),
       ],
     });
@@ -67,11 +81,11 @@ describe('TaskService', () => {
   });
 
   describe('createTask', () => {
-    it('should create a new task', () => {
+    it('should create a new task with formatted dueDate', () => {
       // Act
       service.createTask(mockNewTask).subscribe((task) => {
         // Assert
-        expect(task).toEqual(mockTask);
+        expect(task).toEqual(expectedConvertedTask);
       });
 
       // Assert
@@ -82,11 +96,11 @@ describe('TaskService', () => {
   });
 
   describe('getTasks', () => {
-    it('should return all tasks', () => {
+    it('should return all tasks with formatted dueDate', () => {
       // Act
       service.getTasks().subscribe((tasks) => {
         // Assert
-        expect(tasks).toEqual([mockTask]);
+        expect(tasks).toEqual([expectedConvertedTask]);
       });
 
       // Assert
@@ -146,6 +160,7 @@ describe('TaskService', () => {
       TestBed.configureTestingModule({
         providers: [
           TaskService,
+          { provide: DateService, useValue: stubDateService },
           provideHttpClient(withInterceptors([errorInterceptor])),
         ],
       });

--- a/src/app/services/task.service.ts
+++ b/src/app/services/task.service.ts
@@ -14,24 +14,29 @@ export class TaskService {
 
   private baseUrl = environment.apiUrl;
 
+  // Convert task due date to a format that can be displayed in the UI
+  private mapTaskDates(task: Task): Task {
+    return {
+      ...task,
+      dueDate: this.dateService.convertToDateInput(task.dueDate),
+    };
+  }
+
   createTask(task: Omit<Task, 'id'>): Observable<Task> {
     const taskToCreate = {
       ...task,
       dueDate: this.dateService.convertToISO(task.dueDate),
     };
 
-    return this.http.post<Task>(`${this.baseUrl}/tasks`, taskToCreate);
+    return this.http
+      .post<Task>(`${this.baseUrl}/tasks`, taskToCreate)
+      .pipe(map((createdTask) => this.mapTaskDates(createdTask)));
   }
 
   getTasks(): Observable<Task[]> {
-    return this.http.get<Task[]>(`${this.baseUrl}/tasks`).pipe(
-      map((tasks) =>
-        tasks.map((task) => ({
-          ...task,
-          dueDate: this.dateService.convertToDateInput(task.dueDate),
-        }))
-      )
-    );
+    return this.http
+      .get<Task[]>(`${this.baseUrl}/tasks`)
+      .pipe(map((tasks) => tasks.map((task) => this.mapTaskDates(task))));
   }
 
   updateTask(task: Task): Observable<Task> {


### PR DESCRIPTION
This pull request includes several changes to enhance the functionality and testing of task-related components and services in the application. The main changes involve adding new test cases, removing an unnecessary getter, and integrating date conversion logic into the `TaskService`.

### Enhancements to Testing:

* [`src/app/components/task-new/task-new.component.spec.ts`](diffhunk://#diff-84c419f357b447eed216e0688e009d251baf501c471ced845a1daaaf194df4e9R23): Added new test cases to ensure `addNewTask` is not emitted when the form is invalid and to verify `cancelSave` is emitted on cancel button click. [[1]](diffhunk://#diff-84c419f357b447eed216e0688e009d251baf501c471ced845a1daaaf194df4e9R23) [[2]](diffhunk://#diff-84c419f357b447eed216e0688e009d251baf501c471ced845a1daaaf194df4e9R53-R73) [[3]](diffhunk://#diff-84c419f357b447eed216e0688e009d251baf501c471ced845a1daaaf194df4e9R84)
* [`src/app/services/date.service.spec.ts`](diffhunk://#diff-bd7ba1313b5647cfa8767ad7b3ab17d8f96c79e21b9e3002fd5934dc33e196e3R25-R28): Added a test case to verify that `convertToISO` returns null when given a null date string.
* [`src/app/services/task.service.spec.ts`](diffhunk://#diff-0ba9b77e5bdd5aca3a579b7dab265719c876543c1d62dcea2d3c7be15538ef0dR17-R28): Added a stub for `DateService` and updated test cases to validate the formatted due date in tasks. [[1]](diffhunk://#diff-0ba9b77e5bdd5aca3a579b7dab265719c876543c1d62dcea2d3c7be15538ef0dR17-R28) [[2]](diffhunk://#diff-0ba9b77e5bdd5aca3a579b7dab265719c876543c1d62dcea2d3c7be15538ef0dR60-R71) [[3]](diffhunk://#diff-0ba9b77e5bdd5aca3a579b7dab265719c876543c1d62dcea2d3c7be15538ef0dL70-R88) [[4]](diffhunk://#diff-0ba9b77e5bdd5aca3a579b7dab265719c876543c1d62dcea2d3c7be15538ef0dL85-R103) [[5]](diffhunk://#diff-0ba9b77e5bdd5aca3a579b7dab265719c876543c1d62dcea2d3c7be15538ef0dR163)

### Codebase Simplification:

* [`src/app/components/task/task.component.ts`](diffhunk://#diff-7493c04032d304dd1fcc5a0a3bd5779cc5f83915806e0d74f8b88f93640eec88L32-L38): Removed the unnecessary `validDueDate` getter.

### Integration of Date Conversion Logic:

* [`src/app/services/task.service.ts`](diffhunk://#diff-23543e03d6a9d97a0cf859660b0428a7c5b464e3790573901f371b3ff9beb934R17-R39): Added the `mapTaskDates` method to format task due dates for display in the UI, and updated `createTask` and `getTasks` methods to use this new method.